### PR TITLE
adding redis persistance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ erl_crash.dump
 .idea
 .DS_Store
 Jenkinsfile
+data
 
 # ignore all markdown files (md) beside all README*.md other than README-secret.md
 *.md

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ erl_crash.dump
 *.ez
 
 *.beam
+
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR $HOME/slack_queue_bot
 RUN mix local.hex --force
 RUN mix local.rebar --force
 
+RUN mkdir -p $HOME/slack_queue_bot/data
+
 COPY . $HOME/slack_queue_bot
 RUN chown -R elixir:elixir $HOME/slack_queue_bot
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -19,3 +19,4 @@ SOON:
 * add nginx https
 * if items go from 1 to 0, the broadcast still happens
 * remove *bold* from next in queue broadcast
+* speed up builds -- not enough caching

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,3 +35,5 @@ config :queue_bot, :server,
 config :queue_bot, :slack,
   name: "qubot",
   new_top_items_timeout: 30
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :queue_bot, :redis_client,
+  use_redis: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,11 @@
+use Mix.Config
+
+config :queue_bot, :redis_client,
+  use_redis: true
+
+config :exredis,
+  host: "redis",
+  port: 6379,
+  db: 8,
+  reconnect: 100,
+  max_queue: :infinity

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :queue_bot, :redis_client,
+  use_redis: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   app:
     build: .
@@ -6,3 +6,14 @@ services:
       - 127.0.0.1:4000:4000
     environment:
       - MIX_ENV=prod
+    links:
+      - redis:redis
+    depends_on:
+      - redis
+  redis:
+    image: redis:latest
+    ports:
+      - 127.0.0.1:6379:6379
+    command: redis-server --appendonly yes
+    volumes:
+      - ./data:/data

--- a/lib/queue_bot.ex
+++ b/lib/queue_bot.ex
@@ -10,7 +10,7 @@ defmodule QueueBot do
   @port Application.get_env(:queue_bot, :server)[:port]
 
   def start(_type, _args) do
-    children = [
+    children = redis_worker() ++ [
       Plug.Adapters.Cowboy.child_spec(:http, QueueBot.Router, [], port: @port),
       worker(QueueBot.Manager, [])
     ]
@@ -18,5 +18,13 @@ defmodule QueueBot do
     Logger.info "Started application"
 
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp redis_worker do
+    if Application.get_env(:queue_bot, :redis_client)[:use_redis] do
+      [worker(QueueBot.Redis, [:redis])]
+    else
+      []
+    end
   end
 end

--- a/lib/queue_bot/command.ex
+++ b/lib/queue_bot/command.ex
@@ -22,20 +22,20 @@ defmodule QueueBot.Command do
     |> send_resp(200, Poison.encode!(response))
   end
 
-  defp additional_actions(channel, %{queue: queue, new_first?: true}, url) do
+  defp additional_actions(channel, %{"queue" => queue, "new_first?" => true}, url) do
     attachments =
       case queue do
         [] -> [%{"text": "Queue is now empty"}]
         queue ->
           Enum.map(Enum.zip(Enum.take(queue, 2), ["good", "warning"]),
-            fn {%{item: item}, color} -> %{"text": item, "color": color}
+            fn {%{"item" => item}, color} -> %{"text": item, "color": color}
                {item, color} -> %{"text": item, "color": color}
             end)
       end
 
     body = %{
       "response_type": "in_channel",
-      "text": "*Next in queue:*",
+      "text": "*Next in queue*",
       "attachments": attachments
     }
 
@@ -43,17 +43,17 @@ defmodule QueueBot.Command do
   end
   defp additional_actions(_, _, _), do: nil
 
-  defp response(%{queue: []}, _) do
+  defp response(%{"queue" => []}, _) do
     %{
       "text": "*Queue is empty*",
     }
   end
-  defp response(%{queue: queue}, {_, type}) when elem(type, 0) in [:edit, :remove, :up, :down, :move_to_top] do
+  defp response(%{"queue" => queue}, {_, type}) when elem(type, 0) in [:edit, :remove, :up, :down, :move_to_top] do
     last_index = length(queue) - 1
     attachments =
       queue
       |> Enum.with_index()
-      |> Enum.map(fn {%{id: id, item: item}, index} ->
+      |> Enum.map(fn {%{"id" => id, "item" => item}, index} ->
            buttons = %{
              "text": "#{index + 1}. #{item}",
              "callback_id": "edit_queue",
@@ -102,7 +102,7 @@ defmodule QueueBot.Command do
       "attachments": attachments
     }
   end
-  defp response(%{queue: queue}, {_, type}) when elem(type, 0) in [:display, :push, :broadcast, :pop] do
+  defp response(%{"queue" => queue}, {_, type}) when elem(type, 0) in [:display, :push, :broadcast, :pop] do
     attachments =
       queue
       |> Enum.with_index()

--- a/lib/queue_bot/manager.ex
+++ b/lib/queue_bot/manager.ex
@@ -3,13 +3,14 @@ defmodule QueueBot.Manager do
 
   @name Application.get_env(:queue_bot, :slack)[:name] 
   @new_top_items_timout Application.get_env(:queue_bot, :slack)[:new_top_items_timeout]
+  @use_redis Application.get_env(:queue_bot, :redis_client)[:use_redis]
 
   def start_link() do
     GenServer.start_link(__MODULE__, nil, [name: :manager])
   end
 
   def init(_) do
-    {:ok, %{}}
+    {:ok, load_state(@use_redis)}
   end
 
   def call({channel, action}) do
@@ -19,11 +20,44 @@ defmodule QueueBot.Manager do
   def handle_call({channel, command}, from, state) do
     new_state =
       case state[channel] do
-        nil -> Map.put(state, channel, %{queue: [], delayed_job_ref: nil})
+        nil -> Map.put(state, channel, %{"queue" => [], "delayed_job_ref" => nil})
         _ -> state
       end
 
     do_handle_call({channel, command}, from, new_state)
+    |> persist_result(@use_redis, channel, new_state)
+  end
+
+  defp load_state(true) do
+    persisted_channels =
+      case Exredis.query(:redis, ["KEYS", "*"]) do
+        :no_connection -> []
+        nil -> []
+        channels -> channels
+      end
+
+    Enum.reduce(persisted_channels, %{}, fn channel, acc ->
+      channel_state =
+        Exredis.query(:redis, ["GET", channel])
+        |> Poison.decode!
+      Map.put(acc, channel, channel_state)
+    end)
+  end
+  defp load_state(_) do
+    %{}
+  end
+
+  defp persist_result({_, _, state} = result, true, channel, previous_state) when state != previous_state do
+
+    # run it in the background -- we don't really care if it dies
+    Task.start fn ->
+      recorded_state = Map.put(state[channel], "delayed_job_ref", nil)
+      Exredis.query :redis, ["SET", channel, Poison.encode!(recorded_state)]
+    end
+    result
+  end
+  defp persist_result(result, _, _, _) do
+    result
   end
 
   defp do_handle_call({_, {:help}}, _from, state) do
@@ -40,92 +74,92 @@ defmodule QueueBot.Manager do
   end
   defp do_handle_call({channel, command}, _from, state) when command in [{:display}, {:broadcast}] do
     items =
-      state[channel][:queue]
+      state[channel]["queue"]
       |> get_item_texts()
-    {:reply, %{queue: items, new_first?: false}, state}
+    {:reply, %{"queue" => items, "new_first?" => false}, state}
   end
   defp do_handle_call({channel, {:edit}}, _from, state) do
-    queue = state[channel][:queue]
-    {:reply, %{queue: queue, new_first?: false}, state}
+    queue = state[channel]["queue"]
+    {:reply, %{"queue" => queue, "new_first?" => false}, state}
   end
   defp do_handle_call({channel, {:push, id, item}}, _from, state) do
-    queue = state[channel][:queue]
-    new_queue = queue ++ [%{id: id, item: item}]
+    queue = state[channel]["queue"]
+    new_queue = queue ++ [%{"id" => id, "item" => item}]
     items = get_item_texts(new_queue)
     new_first? = length(queue) in [0,1]
-    {:reply, %{queue: items, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => items, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:pop}}, _from, state) do
-    queue = state[channel][:queue]
+    queue = state[channel]["queue"]
+    new_first? = length(queue) > 0
     new_queue = Enum.drop(queue, 1)
     items = get_item_texts(new_queue)
-    new_first? = length(queue) > 0
-    {:reply, %{queue: items, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => items, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:remove, id}}, _from, state) do
-    queue = state[channel][:queue]
+    queue = state[channel]["queue"]
     {new_queue, new_first?} =
-      case Enum.find_index(queue, &(&1.id == id)) do
+      case Enum.find_index(queue, &(&1["id"] == id)) do
         nil -> {queue, false}
         0 -> {List.delete_at(queue, 0), true}
         1 -> {List.delete_at(queue, 0), true}
         index -> {List.delete_at(queue, index), false}
       end
-    {:reply, %{queue: new_queue, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => new_queue, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:up, id}}, _from, state) do
-    queue = state[channel][:queue]
+    queue = state[channel]["queue"]
     {new_queue, new_first?} =
-      case Enum.find_index(queue, &(&1.id == id)) do
+      case Enum.find_index(queue, &(&1["id"] == id)) do
         nil -> {queue, false}
         0 -> {queue, false}
         1 -> {move_up(queue, 1), true}
         2 -> {move_up(queue, 2), true}
         index -> {move_up(queue, index), false}
       end
-    {:reply, %{queue: new_queue, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => new_queue, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:down, id}}, _from, state) do
-    queue = state[channel][:queue]
+    queue = state[channel]["queue"]
     last_queue_index = length(queue) - 1
     {new_queue, new_first?} =
-      case Enum.find_index(queue, &(&1.id == id)) do
+      case Enum.find_index(queue, &(&1["id"] == id)) do
         nil -> {queue, false}
         ^last_queue_index -> {queue, false}
         0 -> {move_down(queue, 0), true}
         1 -> {move_down(queue, 1), true}
         index -> {move_down(queue, index), false}
       end
-    {:reply, %{queue: new_queue, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => new_queue, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:move_to_top, id}}, _from, state) do
-    queue = state[channel][:queue]
+    queue = state[channel]["queue"]
     {new_queue, new_first?} =
-      case Enum.find_index(queue, &(&1.id == id)) do
+      case Enum.find_index(queue, &(&1["id"] == id)) do
         nil -> {queue, false}
         0 -> {queue, false}
         index -> {move_to_top(queue, index), true}
       end
-    {:reply, %{queue: new_queue, new_first?: new_first?}, put_in(state, [channel, :queue], new_queue)}
+    {:reply, %{"queue" => new_queue, "new_first?" => new_first?}, put_in(state, [channel, "queue"], new_queue)}
   end
   defp do_handle_call({channel, {:delayed_message, url, body}}, from, state) do
-    case state[channel][:delayed_job_ref] do
+    case state[channel]["delayed_job_ref"] do
       nil ->
         sender_ref = Process.send_after(self(), {:delayed_response, channel, url, body}, @new_top_items_timout * 1000)
-        {:reply, :ok, put_in(state, [channel, :delayed_job_ref], sender_ref)}
+        {:reply, :ok, put_in(state, [channel, "delayed_job_ref"], sender_ref)}
       sender_ref ->
         Process.cancel_timer(sender_ref)
-        do_handle_call({channel, {:delayed_message, url, body}}, from, put_in(state, [channel, :delayed_job_ref], nil))
+        do_handle_call({channel, {:delayed_message, url, body}}, from, put_in(state, [channel, "delayed_job_ref"], nil))
     end
   end
 
   def handle_info({:delayed_response, channel, url, body}, state) do
     HTTPoison.post url, body
-    {:noreply, put_in(state, [channel, :delayed_job_ref], nil)}
+    {:noreply, put_in(state, [channel, "delayed_job_ref"], nil)}
   end
 
   def get_item_texts(queue) do
-    Enum.map(queue, &(&1.item))
+    Enum.map(queue, &(&1["item"]))
   end
 
   defp move_up(queue, index) do

--- a/lib/queue_bot/redis.ex
+++ b/lib/queue_bot/redis.ex
@@ -1,0 +1,7 @@
+defmodule QueueBot.Redis do
+  def start_link(name) do
+    {:ok, client} = Exredis.start_link
+    true = Process.register(client, name)
+    {:ok, client}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule QueueBot.Mixfile do
     [{:conform, "~> 2.5.2", runtime: false},
      {:cowboy, "~> 1.1.2"},
      {:distillery, "~> 1.5.2", runtime: false},
+     {:exredis, ">= 0.2.4"},
      {:httpoison, "~> 0.13"},
      {:plug, "~> 1.4.0"},
      {:poison, "~> 2.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,8 @@
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [], [], "hexpm"},
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
+  "eredis": {:hex, :eredis, "1.1.0", "8d8d74496f35216679b97726b75fb1c8715e99dd7f3ef9f9824a2264c3e0aac0", [], [], "hexpm"},
+  "exredis": {:hex, :exredis, "0.2.5", "34d02fa9ef32174cbd790b166746f91b3dbc131ce37a2d9a2451e8bba164b423", [], [{:eredis, ">= 1.0.8", [hex: :eredis, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.10.0", "dcf71c5358ee07c38d5384f6718e6c5871b4461fd7904526bd7510056ef00fd0", [], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -14,28 +14,29 @@ defmodule QueueBot.ManagerTest do
   end
 
   describe "#pop" do
-    test "removes an item", %{channel: channel} do
+    test "removes the top item", %{channel: channel} do
       items = ["so", "ti", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
-      assert length(queue) == 3
-      %{queue: queue} = QueueBot.Manager.call({channel, {:pop}})
-      assert length(queue) == 2
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
+      assert queue == ["so", "ti", "fa"]
+      %{"queue" => new_queue} = QueueBot.Manager.call({channel, {:pop}})
+      assert new_queue == ["ti", "fa"]
     end
 
     test "with no items in the queue returns new_first? false", %{channel: channel} do
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 0
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:pop}})
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:pop}})
       assert new_first? == false
     end
 
     test "with any items in the queue returns new_first? true", %{channel: channel} do
       items = ["Alan", "Chris", "Toulson"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 3
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:pop}})
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:pop}})
+      assert length(new_queue) == 2
       assert new_first? == true
     end
   end
@@ -43,36 +44,36 @@ defmodule QueueBot.ManagerTest do
   describe "#push" do
     test "adds an item", %{channel: channel} do
       item = "alan"
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 0
       add_item(channel, item)
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 1
       assert queue == [item]
     end
 
     test "with no items in the queue returns new_first? true", %{channel: channel} do
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 0
-      %{new_first?: new_first?} = add_item(channel, "write a song")
+      %{"new_first?" => new_first?} = add_item(channel, "write a song")
       assert new_first? == true
     end
 
     test "with one item in the queue returns new_first? true", %{channel: channel} do
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 0
-      %{new_first?: new_first?} = add_item(channel, "write a song")
+      %{"new_first?" => new_first?} = add_item(channel, "write a song")
       assert new_first? == true
-      %{new_first?: new_first?} = add_item(channel, "write another song")
+      %{"new_first?" => new_first?} = add_item(channel, "write another song")
       assert new_first? == true
     end
 
     test "with items in the queue returns new_first? false", %{channel: channel} do
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == 0
       items = ["this", "that", "the other"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{new_first?: new_first?} = add_item(channel, "do another task")
+      %{"new_first?" => new_first?} = add_item(channel, "do another task")
       assert new_first? == false
     end
   end
@@ -81,7 +82,7 @@ defmodule QueueBot.ManagerTest do
     test "returns the current queue", %{channel: channel} do
       items = ["fruit", "vegetables", "circus peanuts"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == length(items) 
       assert Enum.all?(Enum.zip(items, queue), fn {item, queue_item} -> item == queue_item end)
     end
@@ -89,7 +90,7 @@ defmodule QueueBot.ManagerTest do
     test "returns new_first? false", %{channel: channel} do
       items = ["zip", "zap", "zoom"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:display}})
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:display}})
       assert new_first? == false
     end
   end
@@ -98,7 +99,7 @@ defmodule QueueBot.ManagerTest do
     test "returns the current queue", %{channel: channel} do
       items = ["lemons", "limes", "limons"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:broadcast}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:broadcast}})
       assert length(queue) == length(items) 
       assert Enum.all?(Enum.zip(items, queue), fn {item, queue_item} -> item == queue_item end)
     end
@@ -106,7 +107,7 @@ defmodule QueueBot.ManagerTest do
     test "returns new_first? false", %{channel: channel} do
       items = ["coke", "pepsi", "shasta"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:broadcast}})
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:broadcast}})
       assert new_first? == false
     end
   end
@@ -115,15 +116,15 @@ defmodule QueueBot.ManagerTest do
     test "returns the current queue, each with an id and item", %{channel: channel} do
       items = ["medicine", "broth"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      assert Enum.all?(Enum.zip(items, queue), fn {item, %{id: _, item: queue_item}} -> item == queue_item end)
+      assert Enum.all?(Enum.zip(items, queue), fn {item, %{"id" => _, "item" => queue_item}} -> item == queue_item end)
     end
 
     test "returns new_first? false", %{channel: channel} do
       items = ["totally", "radical", "english", "words"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:edit}})
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:edit}})
       assert new_first? == false
     end
   end
@@ -132,41 +133,41 @@ defmodule QueueBot.ManagerTest do
     test "removes an item from the queue", %{channel: channel} do
       items = ["do", "re", "mi", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: id} | _] = queue
+      [%{"id" => id} | _] = queue
       QueueBot.Manager.call({channel, {:remove, id}})
-      %{queue: queue} = QueueBot.Manager.call({channel, {:display}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:display}})
       assert length(queue) == length(items) - 1
     end
 
     test "with multiple items, removing the first, returns new_first? true", %{channel: channel} do
       items = ["so", "do", "la", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: id} | _] = queue
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
+      [%{"id" => id} | _] = queue
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
       assert new_first? == true
     end
 
     test "with multiple items, removing the second, returns new_first? true", %{channel: channel} do
       items = ["la", "mi", "fa", "do"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      %{id: id} = Enum.at(queue, 1)
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
+      %{"id" => id} = Enum.at(queue, 1)
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
       assert new_first? == true
     end
 
     test "with many items, removing any but the first two, returns new_first? false", %{channel: channel} do
       items = ["do", "re", "do"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      %{id: id} = List.last(queue)
-      %{new_first?: new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
+      %{"id" => id} = List.last(queue)
+      %{"new_first?" => new_first?} = QueueBot.Manager.call({channel, {:remove, id}})
       assert new_first? == false
     end
   end
@@ -175,14 +176,14 @@ defmodule QueueBot.ManagerTest do
     test "moves an item up in the queue", %{channel: channel} do
       items = ["sam", "sausage"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: first_id}, %{id: last_id}] = queue
+      [%{"id" => first_id}, %{"id" => last_id}] = queue
       assert first_id != last_id
       QueueBot.Manager.call({channel, {:up, last_id}})
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: new_first_id}, %{id: new_last_id}] = queue
+      [%{"id" => new_first_id}, %{"id" => new_last_id}] = queue
       assert new_first_id == last_id
       assert new_last_id == first_id
     end
@@ -190,9 +191,9 @@ defmodule QueueBot.ManagerTest do
     test "on the first item returns the same queue and new_first? false", %{channel: channel} do
       items = ["simple", "simon"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      [%{id: id} | _] = queue
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:up, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      [%{"id" => id} | _] = queue
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:up, id}})
       assert queue == new_queue
       assert new_first? == false
     end
@@ -200,9 +201,9 @@ defmodule QueueBot.ManagerTest do
     test "on the second, returns new_first? true", %{channel: channel} do
       items = ["so", "do", "la", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 1)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:up, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 1)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:up, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == true
@@ -211,9 +212,9 @@ defmodule QueueBot.ManagerTest do
     test "on the third, returns new_first? true", %{channel: channel} do
       items = ["do", "re", "do"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 2)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:up, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 2)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:up, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == true
@@ -222,9 +223,9 @@ defmodule QueueBot.ManagerTest do
     test "on the fourth, returns new_first? false", %{channel: channel} do
       items = ["mi", "do", "re", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 3)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:up, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 3)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:up, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == false
@@ -235,14 +236,14 @@ defmodule QueueBot.ManagerTest do
     test "moves an item to the top of the queue", %{channel: channel} do
       items = ["simmy", "swanny", "samsonite"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: first_id}, %{id: middle_id}, %{id: last_id}] = queue
+      [%{"id" => first_id}, %{"id" => middle_id}, %{"id" => last_id}] = queue
       assert first_id != last_id
       QueueBot.Manager.call({channel, {:move_to_top, last_id}})
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: new_first_id}, %{id: new_middle_id}, %{id: new_last_id}] = queue
+      [%{"id" => new_first_id}, %{"id" => new_middle_id}, %{"id" => new_last_id}] = queue
       assert new_first_id == last_id
       assert new_middle_id == first_id
       assert new_last_id == middle_id
@@ -251,9 +252,9 @@ defmodule QueueBot.ManagerTest do
     test "on the first item returns the same queue and new_first? false", %{channel: channel} do
       items = ["simple", "simon", "pieman"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      [%{id: id} | _] = queue
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:move_to_top, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      [%{"id" => id} | _] = queue
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:move_to_top, id}})
       assert queue == new_queue
       assert new_first? == false
     end
@@ -261,9 +262,9 @@ defmodule QueueBot.ManagerTest do
     test "on any other, returns new_first? true", %{channel: channel} do
       items = ["p", "q", "m", "n"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 2)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:move_to_top, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 2)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:move_to_top, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == true
@@ -274,14 +275,14 @@ defmodule QueueBot.ManagerTest do
     test "moves an item down in the queue", %{channel: channel} do
       items = ["sam", "sausage"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: first_id}, %{id: last_id}] = queue
+      [%{"id" => first_id}, %{"id" => last_id}] = queue
       assert first_id != last_id
       QueueBot.Manager.call({channel, {:down, first_id}})
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
       assert length(queue) == length(items)
-      [%{id: new_first_id}, %{id: new_last_id}] = queue
+      [%{"id" => new_first_id}, %{"id" => new_last_id}] = queue
       assert new_first_id == last_id
       assert new_last_id == first_id
     end
@@ -289,9 +290,9 @@ defmodule QueueBot.ManagerTest do
     test "on the last item returns the same queue and new_first? false", %{channel: channel} do
       items = ["m", "o"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = List.last(queue)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:down, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = List.last(queue)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:down, id}})
       assert queue == new_queue
       assert new_first? == false
     end
@@ -299,9 +300,9 @@ defmodule QueueBot.ManagerTest do
     test "on the first, returns new_first? true", %{channel: channel} do
       items = ["x", "y", "a", "b"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      [%{id: id} | _] = queue
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:down, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      [%{"id" => id} | _] = queue
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:down, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == true
@@ -310,9 +311,9 @@ defmodule QueueBot.ManagerTest do
     test "on the second, returns new_first? true", %{channel: channel} do
       items = ["o", "p", "q", "r"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 1)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:down, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 1)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:down, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == true
@@ -321,9 +322,9 @@ defmodule QueueBot.ManagerTest do
     test "on the third, returns new_first? false", %{channel: channel} do
       items = ["so", "do", "la", "fa"]
       Enum.each(items, &(add_item(channel, &1)))
-      %{queue: queue} = QueueBot.Manager.call({channel, {:edit}})
-      %{id: id} = Enum.at(queue, 2)
-      %{queue: new_queue, new_first?: new_first?} = QueueBot.Manager.call({channel, {:down, id}})
+      %{"queue" => queue} = QueueBot.Manager.call({channel, {:edit}})
+      %{"id" => id} = Enum.at(queue, 2)
+      %{"queue" => new_queue, "new_first?" => new_first?} = QueueBot.Manager.call({channel, {:down, id}})
       assert queue != new_queue
       assert equal_contents(queue, new_queue)
       assert new_first? == false
@@ -339,6 +340,6 @@ defmodule QueueBot.ManagerTest do
   end
 
   defp order_contents(queue) do
-    Enum.sort_by(queue, fn %{id: id} -> id end)
+    Enum.sort_by(queue, fn %{"id" => id} -> id end)
   end
 end


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/559711262)

a lot of this PR looks to be big changes, but really was a product of needing to serialize and deserialize a set of `Map`s, and doing so required either un-`atom`ifying everything (`Poison.decode!` does that by default, per JSON conventions) or doing some nasty data manipulation after the fact.