### PR TITLE
adding dynamic token config; qubot global messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,14 @@ RUN mix local.rebar --force
 
 RUN mkdir -p $HOME/slack_queue_bot/data
 
+RUN mkdir -p $HOME/.cache
+RUN chown -R elixir:elixir $HOME/.cache
+RUN apt-get update
+RUN apt-get -y install python2.7 python2.7-dev curl
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python2.7 get-pip.py
+RUN pip install awscli --upgrade --user
+
 COPY . $HOME/slack_queue_bot
 RUN chown -R elixir:elixir $HOME/slack_queue_bot
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ just started this server.
 * "Interactive Components"
   * "Request URL": your root endpoint
   * "Options Load URL (for Message Menus)": leave empty
+* "OAuth & Permissions"
+  * "Select Permission Scopes": `Send messages as <YourBotName>`
+  * "OAuth Access Token": add this to config.exs (or an env-specific `Mix.Config` file)
+
+You can also choose to utilize an access token fetcher, also in the `config.exs` file.  It's
+advised not to store any secrets, such as this, in any git repo or public dockerhub image.

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,6 +34,8 @@ config :queue_bot, :server,
 
 config :queue_bot, :slack,
   name: "qubot",
-  new_top_items_timeout: 30
+  new_top_items_timeout: 30,
+  token: nil,
+  token_fetch_command: "aws ssm get-parameters --names slack.qubot-token --with-decryption --region us-east-2 --output text 2>&1 | cut -d$'\t' -f4"
 
 import_config "#{Mix.env}.exs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   app:
     build: .
+    image: alanvoss/slack_queue_bot:latest
     ports:
       - 127.0.0.1:4000:4000
     environment:


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/565581964)

## Automatic Broadcast

There was a bug in my understanding of `response_url`, a header that comes back from both real time messaging commands.  For buttons (editing the queue), it didn't work to use `in_channel` to broadcast to the whole channel, for some reason unbeknownst to me.

Long story short, switching the delayed message with queue update via the QuBot user, which will work every time, and broadcasts to the whole channel, rather than just the user, in this particular case.

I might submit a bug request to slack someday, but frankly, I like this better anyway.

## AWS Decrypt Slack API Token

Since I can't store the sensitive Slack API token in the git repo OR the docker image (using environment variables) without someone potentially being able to compromise (via `git`, `git` history, or `docker inspect`), I've utilized an S3 encrypted bucket workaround that should work.